### PR TITLE
It should be possible to override default headers from inner routes. #1

### DIFF
--- a/src/main/scala/com/sbuslab/http/RestService.scala
+++ b/src/main/scala/com/sbuslab/http/RestService.scala
@@ -117,7 +117,7 @@ class RestService(conf: Config)(implicit system: ActorSystem, ec: ExecutionConte
             }
           } ~
           withJsonMediaTypeIfNotExists {
-            respondWithHeaders(RawHeader("Cache-Control", "no-cache, no-store, must-revalidate")) {
+            respondWithDefaultHeaders(RawHeader("Cache-Control", "no-cache, no-store, must-revalidate")) {
               withRequestTimeoutResponse(_ ⇒ {
                 HttpResponse(status = StatusCodes.GatewayTimeout, entity = HttpEntity(ContentTypes.`application/json`, DefaultErrorFormatter.apply(new ErrorMessage(504, "Request timeout"))))
               }) {


### PR DESCRIPTION
I am trying to add a custom Cache-Control header for an endpoint which responds binary data.
But default Cache control is always included so response have same header multiple times.

```
< Cache-Control: no-cache, no-store, must-revalidate (added by akka-http-tools by default)
< Cache-Control: public, max-age: 31622400 (added by inner route)
```

Ideally when a inner route set same header, it should override akka-http-tools default one.

I suggest to replace
```scala
respondWithHeaders(RawHeader("Cache-Control", "no-cache, no-store, must-revalidate")) {
```
with
```scala
respondWithDefaultHeaders(RawHeader("Cache-Control", "no-cache, no-store, must-revalidate")) {
```