### PR TITLE
STTINT-1226 read the ssl keystore from the filesystem, rather than fr…

### DIFF
--- a/src/main/scala/com/sbuslab/http/RestService.scala
+++ b/src/main/scala/com/sbuslab/http/RestService.scala
@@ -1,7 +1,7 @@
 package com.sbuslab.http
 
 import java.io.StringWriter
-import java.io.InputStream
+import java.io.FileInputStream
 import java.security.{KeyStore, SecureRandom}
 import java.util.UUID
 import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
@@ -120,7 +120,7 @@ class RestService(conf: Config)(implicit system: ActorSystem, ec: ExecutionConte
     val password = conf.getString("ssl.keystore-pass").toCharArray
 
     val ks = KeyStore.getInstance("PKCS12")
-    val keystore = getClass.getClassLoader.getResourceAsStream(conf.getString("ssl.keystore-path"))
+    val keystore = new FileInputStream(conf.getString("ssl.keystore-path"))
 
     require(keystore != null, "Keystore required!")
     ks.load(keystore, password)


### PR DESCRIPTION
…om within Jar

We are currently reading the keystore file from the Classpath, which means that it needs to be bundled inside some jar, at build time.

The keystore file contains a private key and given that this is secret, it makes more sense for it to be read from the filesystem. This way, it can be provided at deploy time.